### PR TITLE
chore: rename oauth-api to oauth-refresh

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2141,7 +2141,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "oauth-api"
+name = "oauth-refresh"
 version = "0.1.0"
 dependencies = [
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "oauth-api"
+name = "oauth-refresh"
 version = "0.1.0"
 edition = "2021"
 
@@ -43,7 +43,7 @@ tracing-subscriber = { version = "0.3.18", features = [
 path = "src/lib.rs"
 
 [[bin]]
-name = "oauth-api"
+name = "oauth-refresh"
 path = "src/main.rs"
 
 [dev-dependencies]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,20 @@
 FROM lukemathwalker/cargo-chef:latest-rust-1.77.0 AS chef
-WORKDIR /app/oauth-api
+WORKDIR /app/oauth-refresh
 
 FROM chef AS planner
 COPY . .
 RUN cargo chef prepare --recipe-path recipe.json
 
 FROM chef AS builder
-COPY --from=planner /app/oauth-api/recipe.json recipe.json
+COPY --from=planner /app/oauth-refresh/recipe.json recipe.json
 # Build dependencies - this is the caching Docker layer!
-RUN cargo chef cook --release --recipe-path recipe.json --bin oauth-api
+RUN cargo chef cook --release --recipe-path recipe.json --bin oauth-refresh
 # Build application
 COPY . .
-RUN cargo build --release --bin oauth-api
+RUN cargo build --release --bin oauth-refresh
 
 FROM debian:bookworm-slim AS runtime
 RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
-COPY --from=builder /app/oauth-api/target/release/oauth-api /usr/local/bin
-ENTRYPOINT /usr/local/bin/oauth-api
+COPY --from=builder /app/oauth-refresh/target/release/oauth-refresh /usr/local/bin
+ENTRYPOINT /usr/local/bin/oauth-refresh

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-# OAuth API
+# OAuth Refresh
 
 This is an API that uses OAuth2.0 blueprints to both refresh tokens and trigger the authorization code flow.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,14 +1,14 @@
 use dotenvy::dotenv;
 use envconfig::Envconfig;
 use integrationos_domain::telemetry::{get_subscriber, init_subscriber};
-use oauth_api::{refresh, AppState, Refresh, RefreshConfig};
+use oauth_refresh::{refresh, AppState, Refresh, RefreshConfig};
 use std::time::Duration;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     dotenv().ok();
 
-    let suscriber = get_subscriber("oauth-api".into(), "info".into(), std::io::stdout);
+    let suscriber = get_subscriber("oauth-refresh".into(), "info".into(), std::io::stdout);
     init_subscriber(suscriber);
 
     let configuration = RefreshConfig::init_from_env()?;


### PR DESCRIPTION
With the introduction of the `platform-oauth` service in https://github.com/integration-os/integrationos/pull/53 we wanted to rename `oauth-api` to `oauth-refresh` to prevent confusion between the two services.

The Docker image was already renamed in https://github.com/integration-os/oauth-rs/pull/13. This PR completes the rename of the service.